### PR TITLE
实现短网址去重及排序，新增删除功能

### DIFF
--- a/islands/DeleteButton.tsx
+++ b/islands/DeleteButton.tsx
@@ -1,0 +1,26 @@
+export default function DeleteButton({ shortCode }: { shortCode: string }) {
+    async function handleDelete() {
+      if (!confirm("Are you sure you want to delete this link?")) return;
+  
+      try {
+        const res = await fetch(`?key=${shortCode}`, { method: "DELETE" });
+  
+        if (res.ok) {
+          alert("Entry deleted successfully!");
+          location.reload();
+        } else {
+          const errorMsg = await res.text();
+          alert(`Failed to delete the entry: ${errorMsg}`);
+        }
+      } catch (err) {
+        console.error("Error deleting entry:", err);
+        alert("An unexpected error occurred.");
+      }
+    }
+  
+    return (
+      <button class="btn btn-danger" onClick={handleDelete}>
+        Delete
+      </button>
+    );
+  }

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -67,7 +67,7 @@ export const handler: Handlers = {
       stats: {access: 0, visibility: form.get("public") ? 'public' : 'private'},
       user: null,
       type: url.startsWith("http") ? "url" : "text",
-      create_time: new Date().toISOString(),
+      create_time: Date.now(),
     };
 
     // 如果是url的话，还要给url本身加上一个索引，方便下次插入时查找是否存在重复


### PR DESCRIPTION
非常喜欢这个轻量化的短链文本二合一项目，用了几天发现存在一些可以改进的地方。

下面是一些已经测试过的改动：

- 增加了**删除**短网址的功能（附带优化了首页的链接数量获取逻辑）
- `/list`页面实现按照创建时间先后**排序**（优化了查询逻辑，方便寻找新增加的链接（靠前））
- 增加了短网址**去重**功能，避免重复存储链接（仅针对链接，文本内容不进行去重）

感谢🙏作者的开发，希望能给这个项目做出一些小贡献。